### PR TITLE
Implements 401 check for typescript and openapi v3

### DIFF
--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -864,6 +864,7 @@ class ApiError {
 class Api {
   protected baseUrl: string = '';
   protected token: string = '';
+  protected _onResponseUnauthorized: () => void;
 
   serializeQueryParams(parameters: QueryParameters) {
     return Object.keys(parameters)
@@ -895,6 +896,10 @@ class Api {
     this.baseUrl = baseUrl;
   }
 
+  set onResponseUnauthorized(callback: () => void) {
+    this._onResponseUnauthorized = callback;
+  }
+
   public setToken(token: string) {
     this.token = token;
   }
@@ -913,6 +918,7 @@ class Api {
     body: any,
     headers: Headers = new Headers(),
     queryParameters: QueryParameters = {},
+    checkFor401 = true,
   ) {
     const queryParams =
       queryParameters && Object.keys(queryParameters).length
@@ -941,6 +947,18 @@ class Api {
     }
 
     const response = await fetch(urlWithParams, { method, headers, body });
+    if (checkFor401) {
+      if (response.status === 401) {
+        if (typeof this._onResponseUnauthorized === 'function') {
+          this._onResponseUnauthorized();
+        } else {
+          const err = new ApiError(response.statusText);
+          err.details = await response.json();
+          throw err;
+        }
+      }
+    }
+
     if (response.ok) {
       const responseContentType =
         (response.headers && response.headers.get('Content-Type')) || '';

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -993,7 +993,7 @@ class Api {
       queryParam4?: Array<string>;
       queryParam5?: string;
     },
-    skip401Callback = false,
+    checkFor401 = true,
   ): Promise<{
     items?: Array<{
       _id?: string;
@@ -1077,7 +1077,7 @@ class Api {
       {},
       headers,
       queryParameters,
-      skip401Callback,
+      checkFor401,
     );
   }
   /**
@@ -1097,7 +1097,7 @@ class Api {
 
       ips?: Array<string | null> | null;
     },
-    skip401Callback = false,
+    checkFor401 = true,
   ): Promise<Something> {
     let path =
       '/path/{path_parameter_1}/segment/{path_parameter_2}/{path_parameter_3}';
@@ -1120,7 +1120,7 @@ class Api {
       body,
       headers,
       queryParameters,
-      skip401Callback,
+      checkFor401,
     );
   }
   /**
@@ -1133,7 +1133,7 @@ class Api {
     form: {
       upload: File;
     },
-    skip401Callback = false,
+    checkFor401 = true,
   ): Promise<{
     _id?: string;
   }> {
@@ -1151,7 +1151,7 @@ class Api {
       form,
       headers,
       queryParameters,
-      skip401Callback,
+      checkFor401,
     );
   }
   /**
@@ -1161,7 +1161,7 @@ class Api {
    */
   endpointWithoutOkResponse(
     parameters: {} = {},
-    skip401Callback = false,
+    checkFor401 = true,
   ): Promise<void> {
     let path = '/endpoint-without-ok-response';
     let headers: Headers = new Headers();
@@ -1175,7 +1175,7 @@ class Api {
       {},
       headers,
       queryParameters,
-      skip401Callback,
+      checkFor401,
     );
   }
   /**
@@ -1185,7 +1185,7 @@ class Api {
    */
   endpointWithAllOf(
     parameters: {} = {},
-    skip401Callback = false,
+    checkFor401 = true,
   ): Promise<
     Array<{
       _id: string;
@@ -1205,7 +1205,7 @@ class Api {
       {},
       headers,
       queryParameters,
-      skip401Callback,
+      checkFor401,
     );
   }
 }

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -993,6 +993,7 @@ class Api {
       queryParam4?: Array<string>;
       queryParam5?: string;
     },
+    skip401Callback = false,
   ): Promise<{
     items?: Array<{
       _id?: string;
@@ -1076,6 +1077,7 @@ class Api {
       {},
       headers,
       queryParameters,
+      skip401Callback,
     );
   }
   /**
@@ -1095,6 +1097,7 @@ class Api {
 
       ips?: Array<string | null> | null;
     },
+    skip401Callback = false,
   ): Promise<Something> {
     let path =
       '/path/{path_parameter_1}/segment/{path_parameter_2}/{path_parameter_3}';
@@ -1117,6 +1120,7 @@ class Api {
       body,
       headers,
       queryParameters,
+      skip401Callback,
     );
   }
   /**
@@ -1129,6 +1133,7 @@ class Api {
     form: {
       upload: File;
     },
+    skip401Callback = false,
   ): Promise<{
     _id?: string;
   }> {
@@ -1146,6 +1151,7 @@ class Api {
       form,
       headers,
       queryParameters,
+      skip401Callback,
     );
   }
   /**
@@ -1153,7 +1159,10 @@ class Api {
    * @method
    * @name Api#endpointWithoutOkResponse
    */
-  endpointWithoutOkResponse(parameters: {} = {}): Promise<void> {
+  endpointWithoutOkResponse(
+    parameters: {} = {},
+    skip401Callback = false,
+  ): Promise<void> {
     let path = '/endpoint-without-ok-response';
     let headers: Headers = new Headers();
     let queryParameters: QueryParameters = {};
@@ -1166,6 +1175,7 @@ class Api {
       {},
       headers,
       queryParameters,
+      skip401Callback,
     );
   }
   /**
@@ -1175,6 +1185,7 @@ class Api {
    */
   endpointWithAllOf(
     parameters: {} = {},
+    skip401Callback = false,
   ): Promise<
     Array<{
       _id: string;
@@ -1194,6 +1205,7 @@ class Api {
       {},
       headers,
       queryParameters,
+      skip401Callback,
     );
   }
 }

--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -27,7 +27,7 @@ function convertType(swaggerType, swagger) {
     );
   } else if (swaggerType.hasOwnProperty('enum')) {
     typespec.tsType = swaggerType.enum
-      .map(function(str) {
+      .map(function (str) {
         return JSON.stringify(str);
       })
       .join(' | ');
@@ -76,7 +76,7 @@ function convertType(swaggerType, swagger) {
       if (swaggerType.allOf) {
         // collect all required properties
         const requiredMap = {};
-        _.forEach(swaggerType.allOf, function(ref) {
+        _.forEach(swaggerType.allOf, function (ref) {
           if ('required' in ref) {
             ref.required.forEach(requiredProperty => {
               requiredMap[requiredProperty] = true;
@@ -84,11 +84,11 @@ function convertType(swaggerType, swagger) {
           }
         });
 
-        _.forEach(swaggerType.allOf, function(ref) {
+        _.forEach(swaggerType.allOf, function (ref) {
           if (ref.$ref) {
             var refSegments = ref.$ref.split('/');
             var name = refSegments[refSegments.length - 1];
-            _.forEach(swagger.definitions, function(
+            _.forEach(swagger.definitions, function (
               definition,
               definitionName,
             ) {
@@ -119,7 +119,7 @@ function convertType(swaggerType, swagger) {
         });
       }
 
-      _.forEach(swaggerType.properties, function(propertyType, propertyName) {
+      _.forEach(swaggerType.properties, function (propertyType, propertyName) {
         var property = convertType(propertyType, swagger);
         property.name = propertyName;
 
@@ -138,6 +138,10 @@ function convertType(swaggerType, swagger) {
      // type unknown or unsupported... just map to 'any'...
      typespec.tsType = 'any';
      }*/
+
+  if (swaggerType.nullable && typespec.tsType) {
+    typespec.nullable = true;
+  }
 
   // Since Mustache does not provide equality checks, we need to do the case distinction via explicit booleans
   typespec.isRef = typespec.tsType === 'ref';

--- a/lib/views/swagger3.js
+++ b/lib/views/swagger3.js
@@ -36,13 +36,13 @@ var getViewForSwagger3 = function (opts, type) {
     className: opts.className,
     domain:
       swagger.schemes &&
-      swagger.schemes.length > 0 &&
-      swagger.host &&
-      swagger.basePath
+        swagger.schemes.length > 0 &&
+        swagger.host &&
+        swagger.basePath
         ? swagger.schemes[0] +
-          '://' +
-          swagger.host +
-          swagger.basePath.replace(/\/+$/g, '')
+        '://' +
+        swagger.host +
+        swagger.basePath.replace(/\/+$/g, '')
         : '',
     methods: [],
     definitions: [],
@@ -116,6 +116,7 @@ var getViewForSwagger3 = function (opts, type) {
         isSecureBasic: secureTypes.includes('basic'),
         parameters: [],
         headers: [],
+        skip401Callback: !!op['x-skip-401-callback'],
       };
       if (method.isSecure && method.isSecureToken) {
         data.isSecureToken = method.isSecureToken;
@@ -190,7 +191,7 @@ var getViewForSwagger3 = function (opts, type) {
           var segments = parameter.$ref.split('/');
           parameter =
             swagger.components.parameters[
-              segments.length === 1 ? segments[0] : segments[3]
+            segments.length === 1 ? segments[0] : segments[3]
             ];
         }
         parameter.camelCaseName = _.camelCase(parameter.name);

--- a/lib/views/swagger3.js
+++ b/lib/views/swagger3.js
@@ -116,7 +116,6 @@ var getViewForSwagger3 = function (opts, type) {
         isSecureBasic: secureTypes.includes('basic'),
         parameters: [],
         headers: [],
-        skip401Callback: !!op['x-skip-401-callback'],
       };
       if (method.isSecure && method.isSecureToken) {
         data.isSecureToken = method.isSecureToken;

--- a/templates/type.mustache
+++ b/templates/type.mustache
@@ -7,11 +7,11 @@
 <%! if its body parameter, then we don't want to generate only readOnly properties (so they don't get send to API)%>
   <%#isBodyParameter%>
     <%^readOnly%>
-      <%name%><%#optional%>?<%/optional%>: <%>type%>;
+      <%name%><%#optional%>?<%/optional%>: <%>type%><%#nullable%> | null<%/nullable%>;
     <%/readOnly%>
   <%/isBodyParameter%>
   <%^isBodyParameter%>
-    <%name%><%#optional%>?<%/optional%>: <%>type%>;
+    <%name%><%#optional%>?<%/optional%>: <%>type%><%#nullable%> | null<%/nullable%>;
   <%/isBodyParameter%>
 <%/properties%>
 }<%/isObject%><%!

--- a/templates/typescript-v3-class.mustache
+++ b/templates/typescript-v3-class.mustache
@@ -43,6 +43,7 @@ class {{&className}} {
             protected apiKey: string | null = null;
         {{/isSecureApiKey}}
     {{/isSecure}}
+    protected _onResponseUnauthorized: () => void;
 
     serializeQueryParams(parameters: QueryParameters) {
         return Object.keys(parameters)
@@ -69,6 +70,10 @@ class {{&className}} {
 
     public setBaseUrl(baseUrl: string) {
         this.baseUrl = baseUrl;
+    }
+
+    set onResponseUnauthorized(callback: () => void) {
+      this._onResponseUnauthorized = callback;
     }
 
     {{#isSecure}}
@@ -100,7 +105,7 @@ class {{&className}} {
     }
     {{/isSecure}}
 
-    private async request(method: string, url: string, body: any, headers: Headers = new Headers(), queryParameters: QueryParameters = {}) {
+    private async request(method: string, url: string, body: any, headers: Headers = new Headers(), queryParameters: QueryParameters = {}, checkFor401 = true) {
         const queryParams = queryParameters && Object.keys(queryParameters).length ? this.serializeQueryParams(queryParameters) : null ;
         const urlWithParams = url + (queryParams ? '?' + queryParams : '');
 
@@ -121,6 +126,18 @@ class {{&className}} {
         }
 
         const response = await fetch(urlWithParams, { method, headers, body });
+        if (checkFor401) {
+          if (response.status === 401) {
+            if (typeof this._onResponseUnauthorized === 'function') {
+            this._onResponseUnauthorized();
+            } else {
+            const err = new ApiError(response.statusText);
+            err.details = await response.json();
+            throw err;
+            }
+          }
+        }
+
         if(response.ok) {
             const responseContentType =
                 (response.headers && response.headers.get('Content-Type')) || '';

--- a/templates/typescript-v3-method.mustache
+++ b/templates/typescript-v3-method.mustache
@@ -115,6 +115,9 @@
         `${this.baseUrl}${path}`,
         {{#hasBody}}{{#isFormMethod}}form{{/isFormMethod}}{{^isFormMethod}}body{{/isFormMethod}}{{/hasBody}}{{^hasBody}}{}{{/hasBody}},
         headers,
-        queryParameters
+        queryParameters,
+        {{#skip401Callback}}
+        false
+        {{/skip401Callback}}
     );
 }

--- a/templates/typescript-v3-method.mustache
+++ b/templates/typescript-v3-method.mustache
@@ -45,7 +45,7 @@
         {{/parameters}}
         }
     {{/hasExtraHeader}}  
-    skip401Callback: boolean = false,
+    skip401Callback = false,
 ): Promise<{{#successResponses}} {{> type}} {{^last}} | {{/last}} {{/successResponses}}{{^successResponses}}void{{/successResponses}}>
 {
     let path = '{{&path}}';

--- a/templates/typescript-v3-method.mustache
+++ b/templates/typescript-v3-method.mustache
@@ -45,7 +45,7 @@
         {{/parameters}}
         }
     {{/hasExtraHeader}}  
-    skip401Callback = false,
+    checkFor401 = true,
 ): Promise<{{#successResponses}} {{> type}} {{^last}} | {{/last}} {{/successResponses}}{{^successResponses}}void{{/successResponses}}>
 {
     let path = '{{&path}}';
@@ -117,6 +117,6 @@
         {{#hasBody}}{{#isFormMethod}}form{{/isFormMethod}}{{^isFormMethod}}body{{/isFormMethod}}{{/hasBody}}{{^hasBody}}{}{{/hasBody}},
         headers,
         queryParameters,
-        skip401Callback,
+        checkFor401,
     );
 }

--- a/templates/typescript-v3-method.mustache
+++ b/templates/typescript-v3-method.mustache
@@ -44,7 +44,8 @@
             {{/isHeaderParameter}}
         {{/parameters}}
         }
-    {{/hasExtraHeader}}
+    {{/hasExtraHeader}}  
+    skip401Callback: boolean = false,
 ): Promise<{{#successResponses}} {{> type}} {{^last}} | {{/last}} {{/successResponses}}{{^successResponses}}void{{/successResponses}}>
 {
     let path = '{{&path}}';
@@ -116,8 +117,6 @@
         {{#hasBody}}{{#isFormMethod}}form{{/isFormMethod}}{{^isFormMethod}}body{{/isFormMethod}}{{/hasBody}}{{^hasBody}}{}{{/hasBody}},
         headers,
         queryParameters,
-        {{#skip401Callback}}
-        false
-        {{/skip401Callback}}
+        skip401Callback,
     );
 }


### PR DESCRIPTION
NOTE: When you want to skip 401 check in responses and don't want to call `_onResponseUnauthorized` callback, just mark your method in openapi3 with ` x-skip-401-callback: true`.