### PR TITLE
Adds lodash import to utilities.js

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,3 +1,5 @@
+var _ = require('lodash');
+
 function matchRuleShort(rule, str) {
   return new RegExp('^' + rule.split('*').join('.*') + '$').test(str);
 }


### PR DESCRIPTION
In case of missing operationId in yaml scheme, method getPathToMethodName is used to generate function name. Generation fails because of missing lodash "_".